### PR TITLE
feat: 增加顺序播放模式

### DIFF
--- a/src/components/PlayerControl.vue
+++ b/src/components/PlayerControl.vue
@@ -311,7 +311,15 @@ const switchQuality = async (option) => {
 
 // 初始化事件回调
 const onSongEnd = () => {
-    if (currentPlaybackModeIndex.value == 2) return;
+    if (currentPlaybackModeIndex.value == 2) return; // 单曲循环
+    // 顺序播放：最后一首播放完毕后停止
+    if (currentPlaybackModeIndex.value == 3) {
+        const currentIndex = musicQueueStore.queue.findIndex(song => song.hash === currentSong.value.hash);
+        if (currentIndex === musicQueueStore.queue.length - 1) {
+            playing.value = false;
+            return;
+        }
+    }
     playSongFromQueue('next');
 };
 
@@ -747,8 +755,19 @@ const playSongFromQueue = async (direction) => {
     } else if (currentPlaybackModeIndex.value === 0) {
         // 随机播放
         targetIndex = handleRandomPlayback(direction, currentIndex);
+    } else if (currentPlaybackModeIndex.value === 3) {
+        // 顺序播放
+        if (direction === 'previous') {
+            targetIndex = currentIndex === 0 ? musicQueueStore.queue.length - 1 : currentIndex - 1;
+        } else {
+            targetIndex = currentIndex + 1;
+            if (targetIndex >= musicQueueStore.queue.length) {
+                playing.value = false;
+                return;
+            }
+        }
     } else {
-        // 顺序播放或单曲循环
+        // 列表循环或单曲循环
         targetIndex = direction === 'previous'
             ? (currentIndex === 0 ? musicQueueStore.queue.length - 1 : currentIndex - 1)
             : (currentIndex + 1) % musicQueueStore.queue.length;

--- a/src/components/player/PlaybackMode.js
+++ b/src/components/player/PlaybackMode.js
@@ -4,7 +4,8 @@ export default function usePlaybackMode(t, audio) {
   const playbackModes = ref([
     { icon: 'fas fa-random', title: t('sui-ji-bo-fang') },
     { icon: 'fas fa-refresh', title: t('lie-biao-xun-huan') },
-    { icon: '', title: t('dan-qu-xun-huan') }
+    { icon: '', title: t('dan-qu-xun-huan') },
+    { icon: 'fas fa-bars-staggered', title: t('shun-xu-bo-fang') }
   ]);
   
   const currentPlaybackModeIndex = ref(1); 


### PR DESCRIPTION
## 🌟 实现了什么？What is added or changed?

在播放器控制组件中新增**顺序播放**模式：

- `src/components/player/PlaybackMode.js`
  - 在播放模式列表中新增「顺序播放」选项（icon: `fas fa-bars-staggered`）
  - 模式索引为 `3`，与随机播放、列表循环、单曲循环并列

- `src/components/PlayerControl.vue`
  - 歌曲自然播放结束且为最后一首时，自动停止播放（不循环回第一首）
  - 手动点击「下一首」到队列末尾时，停止播放
  - 手动点击「上一首」正常回退（到第一首时回到最后一首）

---

## 🎯 为什么需要这个改动？Why is it needed?

目前播放器仅支持随机播放、列表循环和单曲循环三种模式。用户希望在播放歌单时，能够按列表顺序播放一次后自动停止，而不是强制循环。顺序播放是音乐播放器中最基础、最常用的播放模式之一，能够提升用户体验。

---

## 🧪 如何测试？How to test?

- [ ] 添加了单元测试 Added unit tests
- [x] 手动验证通过 Verified manually
- [ ] 不需要额外测试 No additional test needed

**手动验证步骤：**
1. 启动应用，添加一个包含多首歌曲的歌单到播放队列
2. 点击播放模式切换按钮，切换到「顺序播放」模式
3. 播放至最后一首歌曲，确认播放结束后自动停止
4. 在中间歌曲点击「下一首」，确认正常前进
5. 点击「上一首」，确认正常回退；在第一首时点击「上一首」，确认回到最后一首

---

