### PR TITLE
fix(player-control): let artist center

### DIFF
--- a/src/assets/style/PlayerControl.scss
+++ b/src/assets/style/PlayerControl.scss
@@ -291,7 +291,8 @@ $shadow-soft: 0 10px 24px rgba(0, 0, 0, 0.12);
     font-size: 0.9em;
     color: $text-light;
     width: auto;
-    max-width: 300px;
+    // https://github.com/MoeKoeMusic/MoeKoeMusic/issues/1011
+    // max-width: 300px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
## ✨ 变更类型 Type of Change

- [x] Bug 修复 (fix)
- [ ] 新功能 (feat)
- [ ] 文档更新 (docs)
- [x] 样式调整 (style)
- [ ] 重构 (refactor)
- [ ] 测试相关 (test)
- [ ] 构建/工具 (chore)
- [ ] 其他 (other):

---

## 📋 变更描述 Description

请简要描述此次变更内容：
> fix #1011

---

## 🐛 如果是 Bug 修复，请描述问题和修复方法 Bug Fix

- 问题是什么？What was the problem?
  `.artist` 设置了 `max-width` 导致歌曲名长度超过 300 像素时会偏左一点
- 如何修复的？How was it fixed?
  取消 `.artist` 的 `max-width`
---

## ✅ 测试验证 How did you test?

- [x] 本地测试通过 Passed local tests
- [x] 关键功能测试 Tested critical features
- [x] 其他测试描述 (如自动化测试、手动测试等)：
> vite 构建通过

---

## 📚 相关 Issues / Related Issues

> Closes #1011

---

## 📷 截图 / Screenshots (如果适用)

> 修改前
> <img width="388" height="52" alt="image" src="https://github.com/user-attachments/assets/8455e692-8596-4e11-92c4-b6040ca308ae" />
> 修改后
> <img width="399" height="58" alt="image" src="https://github.com/user-attachments/assets/2093b38b-74d9-4567-a936-6087235df030" />

