### PR TITLE
fix(player-control): update smtc info when directly use `audio.play()…

### DIFF
--- a/src/components/PlayerControl.vue
+++ b/src/components/PlayerControl.vue
@@ -979,6 +979,17 @@ const togglePlayPause = async () => {
         playing.value = false;
     } else {
         console.log('[PlayerControl] 开始播放');
+
+        try {
+            mediaSession.changeMediaSession(currentSong.value);
+            // 更新SMTC位置状态
+            if (audio.duration) {
+                mediaSession.updatePositionState(audio.currentTime, audio.duration, currentSpeed.value);
+            }
+        } catch(smtcErr) {
+            console.warn('[PlayerControl] 更新 SMTC 信息失败:', smtcErr);
+        }
+
         try {
             await audio.play();
             playing.value = true;


### PR DESCRIPTION
…` to play a song

## ✨ 变更类型 Type of Change

- [x] Bug 修复 (fix)
- [ ] 新功能 (feat)
- [ ] 文档更新 (docs)
- [ ] 样式调整 (style)
- [ ] 重构 (refactor)
- [ ] 测试相关 (test)
- [ ] 构建/工具 (chore)
- [ ] 其他 (other):

---

## 📋 变更描述 Description

请简要描述此次变更内容：
> 修复刷新/重启客户端后播放歌曲推送错误的 SMTC 信息的问题

---

## 🐛 如果是 Bug 修复，请描述问题和修复方法 Bug Fix

- 问题是什么？What was the problem?
  见上
- 如何修复的？How was it fixed?
https://github.com/LateDreamXD/MoeKoeMusic/commit/f5d1f0896d5d818d11a40a6b73e459db9beff65e#diff-18f1c807bd3bbfb143621f8d6637274b9b5692c92b7e9ee8ccff9e48a08cb42dR981-R992

---

## ✅ 测试验证 How did you test?

- [x] 本地测试通过 Passed local tests
- [x] 关键功能测试 Tested critical features
- [x] 其他测试描述 (如自动化测试、手动测试等)：
> Please describe testing details

---

## 📚 相关 Issues / Related Issues

> Closes #1026

---

## 📷 截图 / Screenshots (如果适用)

> N/A
