### PR TITLE
🐛 fix : 主窗口 webPreferences 增加 backgroundThrottling: false

### DIFF
--- a/electron/appServices.js
+++ b/electron/appServices.js
@@ -64,7 +64,8 @@ export function createWindow() {
             sandbox: false,
             webSecurity: false, // 禁用 CORS、同源策略
             allowRunningInsecureContent: true, // 允许混合内容
-            backgroundThrottling: false,
+            // 默认开启节流；用户在设置中开启该选项时禁用，以修复后台/最小化时 Web Audio 音效失效
+            backgroundThrottling: savedConfig?.backgroundThrottling !== 'on',
             zoomFactor: 1.0
         },
         icon: getIconPath('icon.ico')
@@ -871,3 +872,4 @@ export function sendHashAfterLoad(mainWindow) {
         });
     }
 }
+

--- a/electron/appServices.js
+++ b/electron/appServices.js
@@ -64,6 +64,7 @@ export function createWindow() {
             sandbox: false,
             webSecurity: false, // 禁用 CORS、同源策略
             allowRunningInsecureContent: true, // 允许混合内容
+            backgroundThrottling: false,
             zoomFactor: 1.0
         },
         icon: getIconPath('icon.ico')

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -503,6 +503,20 @@ export const createSettingSections = (t, actions = {}) => computed(() => [
                 available: 'client',
                 label: '日志',
                 customText: '操作'
+            },
+            {
+                key: 'backgroundThrottling',
+                defaultValue: 'off',
+                itemIcon: 'fas fa-bolt',
+                selectionTitle: '禁用后台节流',
+                options: [
+                    { displayText: '打开', value: 'on' },
+                    { displayText: '关闭', value: 'off' }
+                ],
+                available: 'client',
+                label: '禁用后台节流',
+                showRefreshHint: true,
+                refreshHintText: '重启后生效'    
             }
         ]
     }


### PR DESCRIPTION
## ✨ 变更类型 Type of Change

- [x] Bug 修复 (fix)
- [x] 新功能 (feat)
---

## 📋 变更描述 Description

新增一个可选设置项「禁用后台节流」（`backgroundThrottling`），放在「设置 → 系统」分类下、日志项之后，默认关闭。用户可按需手动开启，开启后需重启应用生效。

涉及改动：
- `src/config/settings.js`：系统分类末尾新增 `backgroundThrottling` 开关项（默认 off、带"重启后生效"提示）
- `electron/appServices.js`：主窗口 `webPreferences` 中按该设置决定是否禁用后台节流

---

## 🐛 如果是 Bug 修复，请描述问题和修复方法 Bug Fix

- **问题是什么？**
  当主窗口进入后台（失去焦点、最小化、被完全遮挡）时，依赖 Web Audio API 的音频处理会失效。表现为：
  - 经 `createMediaElementSource` 接入 Web Audio 处理图的音效（如 EQ 插件）在窗口后台时不再生效
  - 音乐本身仍能播放（原生 `<audio>` 不受影响），但 Web Audio 节点的处理被绕过
  
  根因：Chromium 默认开启 `backgroundThrottling`（默认值为 `true`），页面不可见时会将 `AudioContext` 置为 `suspended` 状态，导致经 Web Audio 处理图的链路被中断。
  
- **如何修复的？**
  采用「可选设置项」而非全局禁用的策略：
  - 新增设置项默认关闭，保持 Chromium 默认的节流省电行为
  - 有需要的用户可在「设置 → 系统 → 禁用后台节流」中手动开启，开启后重启生效
  - 开启后 `backgroundThrottling` 设为 `false`，使 `AudioContext` 在后台保持 `running`，Web Audio 处理图持续生效

---

## ✅ 测试验证 How did you test?

- [x] 本地测试通过 Passed local tests
- [x] 关键功能测试 Tested critical features
- [x] 其他测试描述：
  - 设置项出现在「系统」分类末尾，默认关闭
  - 打开后出现"重启后生效"提示
  - 关闭后重启：恢复默认节流行为

---

## 📚 相关 Issues / Related Issues
 #1094 
 https://github.com/RTuioi/MoeKoe-EQ-Plugin/issues/11
---

## 📷 截图 / Screenshots (如果适用)

<img width="300" height="120" alt="image" src="https://github.com/user-attachments/assets/2a05d334-6c2f-4bca-9939-5e44689ce44a" />
<img width="309" height="123" alt="image" src="https://github.com/user-attachments/assets/73ecf9b3-6f4e-46e5-adc6-b27a7326dcdb" />
<img width="921" height="409" alt="image" src="https://github.com/user-attachments/assets/61edb2b1-adc0-4fe1-9f98-a4db23cd80f3" />
