### PR TITLE
🐛 fix: 修复原生窗口装饰器下按 Alt 键弹出默认菜单栏

### DIFF
--- a/electron/appServices.js
+++ b/electron/appServices.js
@@ -72,6 +72,9 @@ export function createWindow() {
     });
     bindExternalLinkHandler(mainWindow);
 
+    // 移除默认菜单，防止原生窗口装饰器下按 Alt 键弹出菜单栏
+    mainWindow.setMenu(null);
+
     if (store.get('maximize')) {
         mainWindow.maximize();
     }


### PR DESCRIPTION
## ✨ 变更类型 Type of Change

- [x] Bug 修复 (fix)

---

## 📋 变更描述 Description

请简要描述此次变更内容：
> Describe your changes here.

- 显式移除Electron应用菜单栏

---

## 🐛 如果是 Bug 修复，请描述问题和修复方法 Bug Fix

- 问题是什么？What was the problem?
- 如何修复的？How was it fixed?

**问题**：原生窗口装饰器 + autoHideMenuBar 下按 Alt 仍会触发 Electron 默认菜单(File/Edit/View/Window/Help)
**修复**：创建主窗口后调用 setMenu(null) 彻底移除默认菜单。

---

## ✅ 测试验证 How did you test?

- [x] 本地测试通过 Passed local tests
- [ ] 关键功能测试 Tested critical features
- [x] 其他测试描述 (如自动化测试、手动测试等)：手动测试，在Windows11家庭版中这个问题被修复
> Please describe testing details

按Alt键不再触发 Electron 默认菜单

---

## 📚 相关 Issues / Related Issues

> Closes #1125  或 Related to #xxx

---

## 📷 截图 / Screenshots (如果适用)

> 如果有界面变动，附上截图或录屏
