### PR TITLE
fix(player): reset stale progress state on track changes

### DIFF
--- a/src/components/PlayerControl.vue
+++ b/src/components/PlayerControl.vue
@@ -584,7 +584,7 @@ const getCurrentLineIndex = (currentTime) => {
 };
 
 const progressBar = useProgressBar(audio, resetLyricsHighlight);
-const { progressWidth, isProgressDragging, showTimeTooltip, tooltipPosition, tooltipTime, climaxPoints, formatTime, getMusicHighlights, onProgressDragStart, updateProgressFromEvent, updateTimeTooltip, hideTimeTooltip } = progressBar;
+const { progressWidth, isProgressDragging, showTimeTooltip, tooltipPosition, tooltipTime, climaxPoints, formatTime, getMusicHighlights, clearMusicHighlights, onProgressDragStart, updateProgressFromEvent, updateTimeTooltip, hideTimeTooltip } = progressBar;
 
 const playbackMode = usePlaybackMode(t, audio);
 const { playbackModes, currentPlaybackModeIndex, currentPlaybackMode, playedSongsStack, currentStackIndex, togglePlaybackMode, setPlaybackMode } = playbackMode;
@@ -593,6 +593,24 @@ const mediaSession = useMediaSession();
 
 const songQueue = useSongQueue(t, musicQueueStore, queueList);
 const { currentSong, NextSong, addSongToQueue, addCloudMusicToQueue, addLocalMusicToQueue, addLocalPlaylistToQueue, addToNext, getPlaylistAllSongs, addPlaylistToQueue, addCloudPlaylistToQueue, restoreLocalSongCover } = songQueue;
+
+const resetTrackTimeline = () => {
+    currentTime.value = 0;
+    progressWidth.value = 0;
+    clearMusicHighlights();
+    resetLyricsHighlight(0);
+    localStorage.setItem('player_progress', '0');
+};
+
+// Queue metadata changes before the playable URL is resolved. Reset as soon
+// as the selected track changes so the old progress/climax markers never sit
+// under the new title while addSongToQueue is still fetching that URL.
+watch(
+    () => currentSong.value?.hash || '',
+    (hash, previousHash) => {
+        if (previousHash && hash !== previousHash) resetTrackTimeline();
+    }
+);
 
 let lyricsBackgroundCarouselTimer = null;
 let lyricsCoverImagesRequestId = 0;
@@ -867,6 +885,12 @@ const playSong = async (song) => {
             return;
         }
 
+        // A track change can happen between timeupdate events.
+        // Reset the visible timeline immediately and invalidate any pending
+        // climax request from the previous song so stale markers cannot be
+        // written back after the new song has started.
+        resetTrackTimeline();
+
         currentSong.value = structuredClone(toPlayerSong(song));
 
         // 应用响度规格化（如果已启用 Web Audio）
@@ -946,7 +970,8 @@ const playSong = async (song) => {
         getVip();
         // 获取歌词
         getCurrentLyrics();
-        getMusicHighlights(currentSong.value.hash);
+        const highlightHash = currentSong.value.hash;
+        getMusicHighlights(highlightHash, () => currentSong.value?.hash === highlightHash);
     } catch (error) {
         console.error('[PlayerControl] 播放音乐时发生错误:', error);
         playing.value = false;

--- a/src/components/player/ClimaxPoints.js
+++ b/src/components/player/ClimaxPoints.js
@@ -1,0 +1,61 @@
+export function normalizeClimaxPoints(data, duration) {
+    const numericDuration = Number(duration);
+    if (!Array.isArray(data) || !Number.isFinite(numericDuration) || numericDuration <= 0) {
+        return [];
+    }
+
+    return data
+        .map(point => {
+            const startTime = Number.parseInt(point?.start_time, 10);
+            const timeLength = Number.parseInt(point?.timelength, 10);
+            if (!Number.isFinite(startTime) || !Number.isFinite(timeLength)) return null;
+
+            const position = (startTime / 1000 / numericDuration) * 100;
+            if (!Number.isFinite(position)) return null;
+
+            return {
+                position: Math.max(0, Math.min(position, 100)),
+                duration: Math.max(0, timeLength / 1000)
+            };
+        })
+        .filter(Boolean);
+}
+
+export function createClimaxPointLoader(fetchHighlights) {
+    let requestId = 0;
+
+    const invalidate = () => {
+        requestId += 1;
+    };
+
+    const load = async (hash, options = {}) => {
+        const {
+            isCurrent = () => true,
+            getDuration = () => Number.NaN
+        } = options;
+
+        if (!isCurrent()) return { apply: false, points: [] };
+
+        const currentRequestId = ++requestId;
+
+        try {
+            const response = await fetchHighlights(hash);
+            if (currentRequestId !== requestId || !isCurrent()) {
+                return { apply: false, points: [] };
+            }
+
+            const points = response?.status === 1
+                ? normalizeClimaxPoints(response.data, getDuration())
+                : [];
+
+            return { apply: true, points };
+        } catch {
+            if (currentRequestId !== requestId || !isCurrent()) {
+                return { apply: false, points: [] };
+            }
+            return { apply: true, points: [] };
+        }
+    };
+
+    return { invalidate, load };
+}

--- a/src/components/player/ProgressBar.js
+++ b/src/components/player/ProgressBar.js
@@ -1,5 +1,6 @@
 import { ref } from 'vue';
 import { get } from '../../utils/request';
+import { createClimaxPointLoader } from './ClimaxPoints';
 
 export default function useProgressBar(audio, resetLyricsHighlight) {
     const progressWidth = ref(0);
@@ -10,6 +11,7 @@ export default function useProgressBar(audio, resetLyricsHighlight) {
     const tooltipTime = ref('0:00');
     const activeProgressBar = ref(null);
     const climaxPoints = ref([]);
+    const climaxPointLoader = createClimaxPointLoader(hash => get(`/song/climax?hash=${hash}`));
 
     // 格式化时间
     const formatTime = (seconds) => {
@@ -20,19 +22,23 @@ export default function useProgressBar(audio, resetLyricsHighlight) {
     };
 
     // 获取歌曲高潮点
-    const getMusicHighlights = async (hash) => {
-        try {
-            const response = await get(`/song/climax?hash=${hash}`);
-            if (response.status !== 1) {
-                climaxPoints.value = [];
-                return;
-            }
-            climaxPoints.value = response.data.map(point => ({
-                position: (parseInt(point.start_time) / 1000 / audio.duration) * 100,
-                duration: parseInt(point.timelength) / 1000
-            }));
-        } catch (error) {
-            climaxPoints.value = [];
+    const clearMusicHighlights = () => {
+        climaxPointLoader.invalidate();
+        climaxPoints.value = [];
+    };
+
+    const getMusicHighlights = async (hash, isCurrentSong = () => true) => {
+        if (!isCurrentSong()) return;
+
+        climaxPoints.value = [];
+
+        const result = await climaxPointLoader.load(hash, {
+            isCurrent: isCurrentSong,
+            getDuration: () => audio.duration
+        });
+
+        if (result.apply) {
+            climaxPoints.value = result.points;
         }
     };
 
@@ -154,9 +160,10 @@ export default function useProgressBar(audio, resetLyricsHighlight) {
         climaxPoints,
         formatTime,
         getMusicHighlights,
+        clearMusicHighlights,
         onProgressDragStart,
         updateProgressFromEvent,
         updateTimeTooltip,
         hideTimeTooltip
     };
-} 
+}


### PR DESCRIPTION
## 🐛 修复了什么？What is fixed?

快速切歌时，新歌曲标题可能先于可播放 URL 更新，而进度条和高潮点仍显示上一首歌的状态；此外，上一首歌的 `/song/climax` 异步响应可能在新歌开始后返回，再次写入旧高潮点。

## 🔍 修复方法 How was it fixed?

- 当前歌曲 hash 变化时立即将时间、进度宽度、歌词高亮和持久化进度重置为 0。
- `playSong()` 开始时再次重置，覆盖重播同一歌曲或切换音质等 hash 不变的路径。
- 将请求序列控制和高潮点规范化集中到 `ClimaxPoints.js`。
- 写入前验证请求仍是最新且歌曲仍然匹配。
- 对响应数组、音频时长和高潮点数值进行校验，并将位置限制在 0–100%。

## ✅ 测试验证 How did you test?

- [x] `npm run build`
- [x] 浏览器快速切歌时旧进度与旧高潮点立即消失

## 🔗 相关 Issues / Related Issues

未找到重复的公开 Issue 或 PR。