### PR TITLE
fix(app-services): use right path of startup sound in prod env

### DIFF
--- a/electron/appServices.js
+++ b/electron/appServices.js
@@ -720,7 +720,7 @@ export function playStartupSound() {
     const randomIndex = Math.floor(Math.random() * audioFiles.length);
     const soundPath = isDev
         ? path.join(__dirname, '..', 'public', audioFiles[randomIndex])
-        : path.join(process.resourcesPath, 'public', audioFiles[randomIndex]);
+        : path.join(process.resourcesPath, '..', audioFiles[randomIndex]);
     try {
         switch (process.platform) {
             case 'win32':


### PR DESCRIPTION
## ✨ 变更类型 Type of Change

- [x] Bug 修复 (fix)

---

## 📋 变更描述 Description

请简要描述此次变更内容：
> fix startup sound

---

## 🐛 如果是 Bug 修复，请描述问题和修复方法 Bug Fix

- 问题是什么？What was the problem?
> 生产环境下无法播放问候语
- 如何修复的？How was it fixed?
> 修复在生产环境下错误的路径引用

---

## ✅ 测试验证 How did you test?

- [x] 本地测试通过 Passed local tests
- [x] 关键功能测试 Tested critical features
- [x] 其他测试描述 (如自动化测试、手动测试等)：
> 手动测试:
>   - 客户端:
>     - win:
>       - 生产环境: 正常

---

## 📚 相关 Issues / Related Issues

> Related to #1145