### PR TITLE
perf(get-vip): use better way to get formatted date string

### DIFF
--- a/src/components/player/Helpers.js
+++ b/src/components/player/Helpers.js
@@ -79,7 +79,9 @@ export function useHelpers(t) {
     const MoeAuth = MoeAuthStore();
     if (!MoeAuth.isAuthenticated) return;
 
-    const todayKey = new Date().toISOString().split('T')[0];
+    const todayKey = new Date().toLocaleDateString('zh-CN', {
+      year: 'numeric', month: '2-digit', day: '2-digit'
+    }).replace(/\//g, '-');
     const lastVipDate = localStorage.getItem('lastVipRequestDate');
 
     if (lastVipDate === todayKey) {

--- a/src/views/Library.vue
+++ b/src/views/Library.vue
@@ -417,7 +417,9 @@ const signIn = async () => {
 }
 const getVip = async () => {
     try {
-        const todayKey = new Date().toISOString().split('T')[0];
+        const todayKey = new Date().toLocaleDateString('zh-CN', {
+            year: 'numeric', month: '2-digit', day: '2-digit'
+        }).replace(/\//g, '-');
         const vipResponse = await get('/youth/day/vip', {
             receive_day: todayKey
         });


### PR DESCRIPTION
## ✨ 变更类型 Type of Change

- [x] 其他 (other):

---

## 📋 变更描述 Description

请简要描述此次变更内容：
> 更换了一套更好的实现来获取格式化日期字符串
> ```js
> new Date().toLocaleDateString('zh-CN', {
>   year: 'numeric', month: '2-digit', day: '2-digit'
> }).replace(/\//g, '-'); // '2026-08-30'
> ```
> 这下不用为时区问题所困了
> 参考资料: [Date.prototype.toLocaleDateString() - JavaScript | MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString)

---

## ✅ 测试验证 How did you test?

- [x] 本地测试通过 Passed local tests
- [x] 关键功能测试 Tested critical features
- [x] 其他测试描述 (如自动化测试、手动测试等)：
> 已通过 BrowserStack 在多款主流浏览器下测试
> 测试的浏览器: Chrome, Edge, FireFox, Opera, Safari

---

## 📚 相关 Issues / Related Issues

> 太多了就不列举了
> 主要是受到了 https://github.com/MoeKoeMusic/MoeKoeMusic/issues/1110#issuecomment-5463965239 这条评论的启发
