### PR TITLE
fix(docker): resolve npm install edgesOut error during image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apk add --no-cache nginx
 COPY ./api ./api
 # Install API dependencies
 WORKDIR /app/api
-RUN npm install --production
+RUN npm install -g npm@11 && npm install --omit=dev
 # Reset WORKDIR to /app
 WORKDIR /app 
 


### PR DESCRIPTION
## ✨ 变更类型 Type of Change

- [x] Bug 修复 (fix)
- [ ] 新功能 (feat)
- [ ] 文档更新 (docs)
- [ ] 样式调整 (style)
- [ ] 重构 (refactor)
- [ ] 测试相关 (test)
- [ ] 构建/工具 (chore)
- [ ] 其他 (other):

---

## 📋 变更描述 Description

请简要描述此次变更内容：
> Describe your changes here.
Dockerfile build不通过，使用npm11解决。
---

## 🐛 如果是 Bug 修复，请描述问题和修复方法 Bug Fix

- 问题是什么？What was the problem?
```
docker compose up -d
WARN[0000] /home/debian/gits/MoeKoeMusic/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
[+] Building 9.0s (16/19)
 => [internal] load local bake definitions                                                                                                         0.3s
 => => reading from stdin 542B                                                                                                                     0.3s
 => [internal] load build definition from Dockerfile                                                                                               0.0s
 => => transferring dockerfile: 1.62kB                                                                                                             0.0s
 => [internal] load metadata for docker.io/library/node:20-alpine                                                                                  0.3s
 => [internal] load .dockerignore                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                    0.0s
 => [frontend-builder 1/7] FROM docker.io/library/node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293           0.0s
 => [internal] load build context                                                                                                                  0.0s
 => => transferring context: 27.81kB                                                                                                               0.0s
 => CACHED [stage-1 3/9] RUN apk add --no-cache nginx                                                                                              0.0s
 => CACHED [stage-1 4/9] COPY ./api ./api                                                                                                          0.0s
 => CACHED [stage-1 5/9] WORKDIR /app/api                                                                                                          0.0s
 => CACHED [frontend-builder 2/7] WORKDIR /app                                                                                                     0.0s
 => CACHED [frontend-builder 3/7] COPY package*.json ./                                                                                            0.0s
 => CACHED [frontend-builder 4/7] RUN node -e "const fs = require('fs'); const filePath = './package.json';              let rawdata = fs.readFil  0.0s
 => CACHED [frontend-builder 5/7] RUN npm install                                                                                                  0.0s
 => CACHED [frontend-builder 6/7] COPY . .                                                                                                         0.0s
 => ERROR [stage-1 6/9] RUN npm install --production                                                                                               8.3s
 => [frontend-builder 7/7] RUN npm run build:docker                                                                                                6.8s
------
 > [stage-1 6/9] RUN npm install --production:
0.421 npm warn config production Use `--omit=dev` instead.
8.122 npm error Cannot read properties of null (reading 'edgesOut')
8.125 npm notice
8.125 npm notice New major version of npm available! 10.8.2 -> 12.0.2
8.125 npm notice Changelog: https://github.com/npm/cli/releases/tag/v12.0.2
8.125 npm notice To update run: npm install -g npm@12.0.2
8.125 npm notice
8.125 npm error A complete log of this run can be found in: /root/.npm/_logs/2026-08-31T01_24_50_563Z-debug-0.log
------
[+] up 0/1
 ⠙ Image moekoemusic-moekoe-music Building                                                                                                          9.1s
Dockerfile:31

--------------------

  29 |     # Install API dependencies

  30 |     WORKDIR /app/api

  31 | >>> RUN npm install --production

  32 |     # Reset WORKDIR to /app

  33 |     WORKDIR /app

--------------------

failed to solve: process "/bin/sh -c npm install --production" did not complete successfully: exit code: 1

```

- 如何修复的？How was it fixed?
使用npm 11
---

## ✅ 测试验证 How did you test?

- [x] 本地测试通过 Passed local tests
- [ ] 关键功能测试 Tested critical features
- [ ] 其他测试描述 (如自动化测试、手动测试等)：
> Please describe testing details

---

## 📚 相关 Issues / Related Issues

> Closes #xxx 或 Related to #xxx

---

## 📷 截图 / Screenshots (如果适用)

> 如果有界面变动，附上截图或录屏
